### PR TITLE
exchanging xarray with rioxarray

### DIFF
--- a/geoengine/workflow.py
+++ b/geoengine/workflow.py
@@ -20,7 +20,8 @@ import rasterio.io
 from vega import VegaLite
 import numpy as np
 from PIL import Image
-import xarray as xr
+import rioxarray
+from xarray import DataArray
 
 from geoengine.types import ProvenanceOutput, QueryRectangle, ResultDescriptor
 from geoengine.auth import get_session
@@ -361,7 +362,7 @@ class Workflow:
         bbox: QueryRectangle,
         timeout=3600,
         force_no_data_value: Optional[float] = None
-    ) -> np.ndarray:
+    ) -> DataArray:
         '''
         Query a workflow and return the raster result as a georeferenced xarray
 
@@ -378,10 +379,19 @@ class Workflow:
             timeout,
             force_no_data_value
         ) as memfile, memfile.open() as dataset:
-            data_array = xr.open_rasterio(dataset)
+            data_array = rioxarray.open_rasterio(dataset)
+
+            # helping mypy with inference
+            assert isinstance(data_array, DataArray)
+
+            rio: DataArray = data_array.rio
+            rio.update_attrs({
+                'crs': rio.crs,
+                'res': rio.resolution(),
+                'transform': rio.transform(),
+            }, inplace=True)
 
             # TODO: add time information to dataset
-
             return data_array.load()
 
     def get_provenance(self, timeout: int = 60) -> List[ProvenanceOutput]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     python-dotenv >=0.19,<0.21
     rasterio >=1.2,<2
     requests >= 2.26,<3
-    rioxarray >=0.11, <1
+    rioxarray >=0.9.1, <0.10
     vega >= 3.5,<4
     xarray >=0.19,<2022.4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     python-dotenv >=0.19,<0.21
     rasterio >=1.2,<2
     requests >= 2.26,<3
+    rioxarray >=0.11, <1
     vega >= 3.5,<4
     xarray >=0.19,<2022.4
 

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -408,26 +408,43 @@ class WcsTests(unittest.TestCase):
                     [255, 255, 115, 255, 139, 255, 255, 255],
                     [255, 255, 255, 255, 255, 255, 255, 255],
                     [255, 255, 255, 255, 255, 255, 255, 255]
-                ]]),
+                ]], dtype=np.uint8),
                 coords={
                     'band': [1],
+                    'x': [-157.5, -112.5, -67.5, -22.5, 22.5, 67.5, 112.5, 157.5],
                     'y': [78.75, 56.25, 33.75, 11.25, -11.25, -33.75, -56.25, -78.75],
-                    'x': [-157.5, -112.5, -67.5, -22.5, 22.5, 67.5, 112.5, 157.5]
+                    'spatial_ref': 0,
                 },
                 dims=["band", "y", "x"],
                 attrs={
-                    'transform': (45.0, 0.0, -180.0, 0.0, -22.5, 90.0),
-                    'crs': '+init=epsg:4326',
-                    'res': (45.0, 22.5),
-                    'is_tiled': False,
-                    'nodatavals': (0.0,),
-                    'scales': (1.0,),
-                    'offsets': (0.0,),
-                    'AREA_OR_POINT': 'Area',
+                    'transform': (45.0, 0.0, -180.0, 0.0, -22.5, 90.0, 0.0, 0.0, 1.0),
+                    'crs': 'EPSG:4326',
+                    'res': (45.0, -22.5),
+                    'scale_factor': 1.0,
+                    '_FillValue': 0.0,
+                    'add_offset': 0.0,
                 },
             )
 
-            self.assertTrue(array.identical(expected), msg=f'{array}\n!=\n{expected}')
+            # https://github.com/corteva/rioxarray/blob/ca62a67a3db3aa62afc85e57bb6153dbc503e1dd/test/integration/test_integration_rioxarray.py
+            # test actual array data
+            self.assertTrue(np.array_equal(array.data, expected.data), msg=f'{array.data} \n!=\n {expected.data}')
+
+            # test dims
+            self.assertEqual(array.dims, expected.dims, msg=f'{array.dims} \n!=\n {expected.dims}')
+
+            # test coords
+            self.assertTrue(
+                np.array_equal(
+                    array.coords,
+                    expected.coords),
+                msg=f'{array.coords} \n!=\n {expected.coords}')
+
+            # test attributes
+            self.assertTrue(
+                np.array_equal(
+                    array.attrs, expected.attrs),
+                msg=f'{array.attrs} \n!=\n {expected.attrs}')
 
 
 if __name__ == '__main__':

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -426,7 +426,6 @@ class WcsTests(unittest.TestCase):
                 },
             )
 
-            # https://github.com/corteva/rioxarray/blob/ca62a67a3db3aa62afc85e57bb6153dbc503e1dd/test/integration/test_integration_rioxarray.py
             # test actual array data
             self.assertTrue(np.array_equal(array.data, expected.data), msg=f'{array.data} \n!=\n {expected.data}')
 


### PR DESCRIPTION
This PR exchanges the deprecated [xarray open_rasterio](https://docs.xarray.dev/en/stable/generated/xarray.open_rasterio.html) method with [rioxarray open_rasterio](https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray-open-rasterio).

Note: The attributes/fields of the DataArray changed a bit with rio.